### PR TITLE
Fix typo in honeycomb.yml example

### DIFF
--- a/.github/workflows/honeycomb.yml
+++ b/.github/workflows/honeycomb.yml
@@ -8,7 +8,7 @@ on:
     types: [completed]
 
 jobs:
-  otel-export-newrelic:
+  otel-export-honeycomb:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This fixes a small typo in the honeycomb example.