### PR TITLE
Add extraAttributes to action defintion

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   runId:
     description: Workflow Run ID to Export. Defaults to env.GITHUB_RUN_ID
     required: false
+  extraAttributes:
+    description: Extra resource attributes
+    required: false
 outputs:
   traceId:
     description: The OpenTelemetry Trace ID of the root span


### PR DESCRIPTION
Currently, `extraAttributes` is not a visible input for the action...

```
Unexpected input(s) 'extraAttributes', valid inputs are ['otlpEndpoint', 'otlpHeaders', 'otelServiceName', 'githubToken', 'runId']
```

Thank you for your great work with this action 🎉